### PR TITLE
build: fix release-please action

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -43,7 +43,7 @@ jobs:
           manifest-file: .release-please-manifest_dev.json
           target-branch: ${{ github.ref_name }}
       - name: Create a release
-        if: ${{ contains(fromJSON('["main", "master"]'), github.ref_name }}
+        if: ${{ contains(fromJSON('["main", "master"]'), github.ref_name) }}
         uses: googleapis/release-please-action@v4
         with:
           # do NOT use 'secrets.GITHUB_TOKEN':


### PR DESCRIPTION
fix the following issue on https://github.com/feeph/libi2c-emc2101-python/blob/059d22e3fe934c7fc2866bb8b34cecffefb444e8/.github/workflows/release-please.yaml#L46

> Invalid workflow file
> The workflow is not valid. .github/workflows/release-please.yaml (Line: 46, Col: 13): Unexpected end of expression: 'ref_name'.